### PR TITLE
feat: Initial implementation of the Operation Theatre module

### DIFF
--- a/UniCareERP.Application.Tests/Services/InventoryServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/InventoryServiceTests.cs
@@ -45,10 +45,6 @@ namespace UniCareERP.Application.Tests.Services
             _mockContext.Setup(c => c.InventoryItems).Returns(_mockItemDbSet.Object);
             _mockContext.Setup(c => c.StockTransactions).Returns(_mockTransactionDbSet.Object);
 
-            var mockTransaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
-            _mockContext.Setup(c => c.Database.BeginTransactionAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(mockTransaction.Object);
-
             _mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
             _inventoryService = new InventoryService(_mockContext.Object, _mockLogger.Object);

--- a/UniCareERP.Application.Tests/Services/InvoiceServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/InvoiceServiceTests.cs
@@ -50,11 +50,6 @@ namespace UniCareERP.Application.Tests.Services
             _mockContext.Setup(c => c.Invoices).Returns(_mockInvoiceDbSet.Object);
             _mockContext.Setup(c => c.Patients).Returns(_mockPatientDbSet.Object);
 
-            // Mock transaction
-            var mockTransaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
-            _mockContext.Setup(c => c.Database.BeginTransactionAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(mockTransaction.Object);
-
             _mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
             _invoiceService = new InvoiceService(_mockContext.Object, _mockLogger.Object);

--- a/UniCareERP.Application.Tests/Services/PatientServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/PatientServiceTests.cs
@@ -22,6 +22,8 @@ namespace UniCareERP.Application.Tests.Services
         private Mock<ILogger<PatientService>> _mockLogger;
         private PatientService _patientService;
 
+        private List<Patient> _seedPatients;
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -29,16 +31,10 @@ namespace UniCareERP.Application.Tests.Services
             _mockDbSet = new Mock<DbSet<Patient>>();
             _mockLogger = new Mock<ILogger<PatientService>>();
 
-            // Setup DbSet properties and methods
-            var patients = new List<Patient>().AsQueryable();
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.Provider).Returns(patients.Provider);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.Expression).Returns(patients.Expression);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.ElementType).Returns(patients.ElementType);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.GetEnumerator()).Returns(patients.GetEnumerator());
+            _seedPatients = new List<Patient>();
 
-            _mockDbSet.Setup(d => d.Add(It.IsAny<Patient>())).Callback<Patient>((s) => patients.ToList().Add(s)); // Simulate Add
-            _mockDbSet.Setup(d => d.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) => patients.FirstOrDefault(p => p.Id == (Guid)ids[0]));
-
+            // Setup DbSets
+            SetupMockDbSet(_mockDbSet, _seedPatients);
 
             _mockContext.Setup(c => c.Patients).Returns(_mockDbSet.Object);
             _mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
@@ -47,34 +43,32 @@ namespace UniCareERP.Application.Tests.Services
             _patientService = new PatientService(_mockContext.Object, _mockLogger.Object);
         }
 
-        private List<Patient> GetSeedPatients()
+        // Generic DbSet Mock Setup
+        private void SetupMockDbSet<TEntity>(Mock<DbSet<TEntity>> mockDbSet, List<TEntity> sourceList) where TEntity : class
         {
-            return new List<Patient>
-            {
-                new Patient { Id = Guid.NewGuid(), FirstName = "John", LastName = "Doe", PatientCode = "P00001", DateOfBirth = new DateTime(1980,1,1), Gender="Male" },
-                new Patient { Id = Guid.NewGuid(), FirstName = "Jane", LastName = "Smith", PatientCode = "P00002", DateOfBirth = new DateTime(1990,5,5), Gender="Female" }
-            };
-        }
+            var queryableList = sourceList.AsQueryable();
+            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<TEntity>(queryableList.Provider));
+            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(queryableList.Expression);
+            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(queryableList.ElementType);
+            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => queryableList.GetEnumerator());
 
-        private void SetupMockDbSet(List<Patient> patients)
-        {
-            var queryablePatients = patients.AsQueryable();
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.Provider).Returns(queryablePatients.Provider);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.Expression).Returns(queryablePatients.Expression);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.ElementType).Returns(queryablePatients.ElementType);
-            _mockDbSet.As<IQueryable<Patient>>().Setup(m => m.GetEnumerator()).Returns(() => queryablePatients.GetEnumerator());
-            _mockDbSet.Setup(d => d.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) => queryablePatients.FirstOrDefault(p => p.Id == (Guid)ids[0]));
-            _mockDbSet.Setup(m => m.Add(It.IsAny<Patient>())).Callback<Patient>(s => patients.Add(s));
-            _mockDbSet.Setup(m => m.Remove(It.IsAny<Patient>())).Callback<Patient>(s => patients.Remove(s));
+            mockDbSet.As<IAsyncEnumerable<TEntity>>()
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<TEntity>(queryableList.GetEnumerator()));
+
+            mockDbSet.Setup(d => d.FindAsync(It.IsAny<object[]>()))
+                .ReturnsAsync((object[] ids) => {
+                    if (typeof(TEntity) == typeof(Patient)) return sourceList.FirstOrDefault(e => (e as Patient).Id == (Guid)ids[0]) as TEntity;
+                    return null;
+                });
+            mockDbSet.Setup(d => d.Add(It.IsAny<TEntity>())).Callback<TEntity>(s => sourceList.Add(s));
+            mockDbSet.Setup(d => d.Remove(It.IsAny<TEntity>())).Callback<TEntity>(s => sourceList.Remove(s));
         }
 
 
         [TestMethod]
         public async Task GenerateNextPatientCodeAsync_NoExistingPatients_ReturnsP00001()
         {
-            // Arrange
-            SetupMockDbSet(new List<Patient>()); // No patients
-
             // Act
             var code = await _patientService.GenerateNextPatientCodeAsync();
 
@@ -86,12 +80,8 @@ namespace UniCareERP.Application.Tests.Services
         public async Task GenerateNextPatientCodeAsync_WithExistingPatients_ReturnsCorrectNextCode()
         {
             // Arrange
-             var patients = new List<Patient> { new Patient { PatientCode = "P00001" }, new Patient { PatientCode = "P00002" } };
-            SetupMockDbSet(patients);
-             _mockDbSet.As<IAsyncEnumerable<Patient>>() // For OrderByDescending(...).FirstOrDefaultAsync()
-                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
-                .Returns(new TestAsyncEnumerator<Patient>(patients.OrderByDescending(p=>p.PatientCode).AsQueryable().GetEnumerator()));
-
+            _seedPatients.Add(new Patient { PatientCode = "P00001" });
+            _seedPatients.Add(new Patient { PatientCode = "P00002" });
 
             // Act
             var code = await _patientService.GenerateNextPatientCodeAsync();
@@ -106,8 +96,6 @@ namespace UniCareERP.Application.Tests.Services
         {
             // Arrange
             var createDto = new CreatePatientDto { FirstName = "New", LastName = "Patient", DateOfBirth = new DateTime(2000,1,1), Gender="Male" };
-            SetupMockDbSet(new List<Patient>());
-
 
             // Act
             var resultDto = await _patientService.CreatePatientAsync(createDto);
@@ -125,8 +113,7 @@ namespace UniCareERP.Application.Tests.Services
         {
             // Arrange
             var patientId = Guid.NewGuid();
-            var patients = new List<Patient> { new Patient { Id = patientId, FirstName = "Test", LastName = "User", PatientCode="P00001", DateOfBirth = DateTime.Now, Gender="Test" } };
-            SetupMockDbSet(patients);
+            _seedPatients.Add(new Patient { Id = patientId, FirstName = "Test", LastName = "User", PatientCode="P00001", DateOfBirth = DateTime.Now, Gender="Test" });
 
             // Act
             var resultDto = await _patientService.GetPatientByIdAsync(patientId);
@@ -139,9 +126,6 @@ namespace UniCareERP.Application.Tests.Services
         [TestMethod]
         public async Task GetPatientByIdAsync_PatientDoesNotExist_ReturnsNull()
         {
-            // Arrange
-            SetupMockDbSet(new List<Patient>());
-
             // Act
             var resultDto = await _patientService.GetPatientByIdAsync(Guid.NewGuid());
 
@@ -153,12 +137,8 @@ namespace UniCareERP.Application.Tests.Services
         public async Task GetAllPatientsAsync_ReturnsAllPatientDtos()
         {
             // Arrange
-            var seedPatients = GetSeedPatients();
-            SetupMockDbSet(seedPatients);
-             _mockDbSet.As<IAsyncEnumerable<Patient>>() // For ToListAsync()
-                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
-                .Returns(new TestAsyncEnumerator<Patient>(seedPatients.AsQueryable().GetEnumerator()));
-
+            _seedPatients.Add(new Patient { Id = Guid.NewGuid(), FirstName = "John", LastName = "Doe", PatientCode = "P00001", DateOfBirth = new DateTime(1980,1,1), Gender="Male" });
+            _seedPatients.Add(new Patient { Id = Guid.NewGuid(), FirstName = "Jane", LastName = "Smith", PatientCode = "P00002", DateOfBirth = new DateTime(1990,5,5), Gender="Female" });
 
             // Act
             var results = await _patientService.GetAllPatientsAsync();
@@ -173,8 +153,7 @@ namespace UniCareERP.Application.Tests.Services
         {
             // Arrange
             var patientId = Guid.NewGuid();
-            var patients = new List<Patient> { new Patient { Id = patientId, FirstName = "OldName", LastName="OldLast", PatientCode="P00001", DateOfBirth=DateTime.Now, Gender="Old" } };
-            SetupMockDbSet(patients);
+            _seedPatients.Add(new Patient { Id = patientId, FirstName = "OldName", LastName="OldLast", PatientCode="P00001", DateOfBirth=DateTime.Now, Gender="Old" });
 
             var updateDto = new UpdatePatientDto { Id = patientId, FirstName = "NewName", LastName="NewLast", DateOfBirth = DateTime.Now.AddYears(-20), Gender="New" };
 
@@ -183,7 +162,7 @@ namespace UniCareERP.Application.Tests.Services
 
             // Assert
             Assert.IsTrue(result);
-            var updatedPatient = patients.First(p => p.Id == patientId);
+            var updatedPatient = _seedPatients.First(p => p.Id == patientId);
             Assert.AreEqual("NewName", updatedPatient.FirstName);
             _mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
         }
@@ -192,7 +171,6 @@ namespace UniCareERP.Application.Tests.Services
         public async Task UpdatePatientAsync_PatientDoesNotExist_ReturnsFalse()
         {
             // Arrange
-            SetupMockDbSet(new List<Patient>());
             var updateDto = new UpdatePatientDto { Id = Guid.NewGuid(), FirstName = "Test" };
 
             // Act
@@ -208,8 +186,7 @@ namespace UniCareERP.Application.Tests.Services
         {
             // Arrange
             var patientId = Guid.NewGuid();
-            var patients = new List<Patient> { new Patient { Id = patientId, FirstName = "Test" } };
-            SetupMockDbSet(patients);
+            _seedPatients.Add(new Patient { Id = patientId, FirstName = "Test" });
 
             // Act
             var result = await _patientService.DeletePatientAsync(patientId);
@@ -218,15 +195,12 @@ namespace UniCareERP.Application.Tests.Services
             Assert.IsTrue(result);
             _mockDbSet.Verify(db => db.Remove(It.IsAny<Patient>()), Times.Once());
             _mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once());
-            Assert.IsFalse(patients.Any(p => p.Id == patientId)); // Check if removed from the list used by mock
+            Assert.IsFalse(_seedPatients.Any(p => p.Id == patientId)); // Check if removed from the list used by mock
         }
 
         [TestMethod]
         public async Task DeletePatientAsync_PatientDoesNotExist_ReturnsFalse()
         {
-            // Arrange
-            SetupMockDbSet(new List<Patient>());
-
             // Act
             var result = await _patientService.DeletePatientAsync(Guid.NewGuid());
 

--- a/UniCareERP.Application.Tests/Services/PrescriptionServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/PrescriptionServiceTests.cs
@@ -12,6 +12,7 @@ using UniCareERP.Domain.Entities.Inventory;
 using UniCareERP.Domain.Entities.Patients;
 using UniCareERP.Domain.Enums;
 using UniCareERP.Infrastructure.Data;
+using UniCareERP.Application.Tests.Helpers;
 
 namespace UniCareERP.Application.Tests.Services
 {
@@ -58,10 +59,20 @@ namespace UniCareERP.Application.Tests.Services
         private void SetupMockDbSet<TEntity>(Mock<DbSet<TEntity>> mockDbSet, List<TEntity> sourceList) where TEntity : class
         {
             var queryableList = sourceList.AsQueryable();
-            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(queryableList.Provider);
+            mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<TEntity>(queryableList.Provider));
             mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(queryableList.Expression);
             mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(queryableList.ElementType);
             mockDbSet.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => queryableList.GetEnumerator());
+
+            mockDbSet.As<IAsyncEnumerable<TEntity>>()
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<TEntity>(queryableList.GetEnumerator()));
+
+            mockDbSet.Setup(d => d.FindAsync(It.IsAny<object[]>()))
+                .ReturnsAsync((object[] ids) => {
+                    if (typeof(TEntity) == typeof(Prescription)) return sourceList.FirstOrDefault(e => (e as Prescription).Id == (Guid)ids[0]) as TEntity;
+                    return null;
+                });
             mockDbSet.Setup(d => d.Add(It.IsAny<TEntity>())).Callback<TEntity>(s => sourceList.Add(s));
         }
 

--- a/UniCareERP.Application.Tests/Services/PurchaseOrderServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/PurchaseOrderServiceTests.cs
@@ -45,10 +45,6 @@ namespace UniCareERP.Application.Tests.Services
             SetupMockDbSet(_mockPoDbSet, _seedPOs);
             _mockContext.Setup(c => c.PurchaseOrders).Returns(_mockPoDbSet.Object);
 
-            var mockTransaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
-            _mockContext.Setup(c => c.Database.BeginTransactionAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(mockTransaction.Object);
-
             _mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
             _poService = new PurchaseOrderService(_mockContext.Object, _mockInventoryService.Object, _mockLogger.Object);

--- a/UniCareERP.Application.Tests/Services/SaleServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/SaleServiceTests.cs
@@ -57,10 +57,6 @@ namespace UniCareERP.Application.Tests.Services
                         .Returns((object[] ids) => _seedItems.FirstOrDefault(i => i.Id == (Guid)ids[0]));
 
 
-            var mockTransaction = new Mock<Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction>();
-            _mockContext.Setup(c => c.Database.BeginTransactionAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(mockTransaction.Object);
-
             _mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
             _saleService = new SaleService(_mockContext.Object, _mockInventoryService.Object, _mockInvoiceService.Object, _mockLogger.Object);

--- a/UniCareERP.Application.Tests/Services/VitalServiceTests.cs
+++ b/UniCareERP.Application.Tests/Services/VitalServiceTests.cs
@@ -1,0 +1,41 @@
+using Moq;
+using System;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.Vitals;
+using UniCareERP.Application.Services.Vitals;
+using Xunit;
+
+namespace UniCareERP.Application.Tests.Services
+{
+    public class VitalServiceTests
+    {
+        [Fact]
+        public async Task CreateVitalAsync_ShouldReturnVitalDto()
+        {
+            // Arrange
+            var vitalDto = new VitalDto
+            {
+                PatientId = Guid.NewGuid(),
+                TemperatureC = 36.5m,
+                BloodPressureSystolic = 120,
+                BloodPressureDiastolic = 80,
+                HeartRate = 70,
+                RespiratoryRate = 16,
+                OxygenSaturation = 98
+            };
+
+            var mockVitalService = new Mock<IVitalService>();
+            mockVitalService.Setup(s => s.CreateVitalAsync(It.IsAny<VitalDto>()))
+                .ReturnsAsync(vitalDto);
+
+            var service = mockVitalService.Object;
+
+            // Act
+            var result = await service.CreateVitalAsync(vitalDto);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(vitalDto.PatientId, result.PatientId);
+        }
+    }
+}

--- a/UniCareERP.Application/DTOs/OperationTheatre/OperationTheatreDto.cs
+++ b/UniCareERP.Application/DTOs/OperationTheatre/OperationTheatreDto.cs
@@ -1,0 +1,10 @@
+namespace UniCareERP.Application.DTOs.OperationTheatre
+{
+    public class OperationTheatreDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Location { get; set; }
+        public bool IsAvailable { get; set; }
+    }
+}

--- a/UniCareERP.Application/DTOs/OperationTheatre/SurgeryChecklistDto.cs
+++ b/UniCareERP.Application/DTOs/OperationTheatre/SurgeryChecklistDto.cs
@@ -1,0 +1,13 @@
+using System;
+using UniCareERP.Domain.Enums.OperationTheatre;
+
+namespace UniCareERP.Application.DTOs.OperationTheatre
+{
+    public class SurgeryChecklistDto
+    {
+        public Guid Id { get; set; }
+        public Guid SurgeryId { get; set; }
+        public string ChecklistName { get; set; }
+        public ChecklistStatus Status { get; set; }
+    }
+}

--- a/UniCareERP.Application/DTOs/OperationTheatre/SurgeryDto.cs
+++ b/UniCareERP.Application/DTOs/OperationTheatre/SurgeryDto.cs
@@ -1,0 +1,22 @@
+using System;
+using UniCareERP.Domain.Enums.OperationTheatre;
+
+namespace UniCareERP.Application.DTOs.OperationTheatre
+{
+    public class SurgeryDto
+    {
+        public Guid Id { get; set; }
+        public string SurgeryName { get; set; }
+        public Guid PatientId { get; set; }
+        public string PatientName { get; set; }
+        public Guid OperationTheatreId { get; set; }
+        public string OperationTheatreName { get; set; }
+        public DateTime ScheduledDateTime { get; set; }
+        public Guid PrimarySurgeonId { get; set; }
+        public string PrimarySurgeonName { get; set; }
+        public Guid AnesthetistId { get; set; }
+        public string AnesthetistName { get; set; }
+        public string Notes { get; set; }
+        public SurgeryStatus Status { get; set; }
+    }
+}

--- a/UniCareERP.Application/DTOs/Vitals/VitalDto.cs
+++ b/UniCareERP.Application/DTOs/Vitals/VitalDto.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace UniCareERP.Application.DTOs.Vitals
+{
+    public class VitalDto
+    {
+        public Guid Id { get; set; }
+        public Guid PatientId { get; set; }
+        public string PatientName { get; set; }
+        public string RecordedById { get; set; }
+        public string RecordedByName { get; set; }
+        public DateTime RecordedAt { get; set; }
+        public decimal TemperatureC { get; set; }
+        public decimal TemperatureF { get; set; }
+        public int BloodPressureSystolic { get; set; }
+        public int BloodPressureDiastolic { get; set; }
+        public int HeartRate { get; set; }
+        public int RespiratoryRate { get; set; }
+        public int OxygenSaturation { get; set; }
+    }
+}

--- a/UniCareERP.Application/Services/OperationTheatre/IOperationTheatreService.cs
+++ b/UniCareERP.Application/Services/OperationTheatre/IOperationTheatreService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.OperationTheatre;
+
+namespace UniCareERP.Application.Services.OperationTheatre
+{
+    public interface IOperationTheatreService
+    {
+        Task<IEnumerable<OperationTheatreDto>> GetAllOperationTheatresAsync();
+        Task<OperationTheatreDto> GetOperationTheatreByIdAsync(Guid id);
+        Task<OperationTheatreDto> CreateOperationTheatreAsync(OperationTheatreDto operationTheatreDto);
+        Task UpdateOperationTheatreAsync(Guid id, OperationTheatreDto operationTheatreDto);
+        Task DeleteOperationTheatreAsync(Guid id);
+    }
+}

--- a/UniCareERP.Application/Services/OperationTheatre/ISurgeryService.cs
+++ b/UniCareERP.Application/Services/OperationTheatre/ISurgeryService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.OperationTheatre;
+
+namespace UniCareERP.Application.Services.OperationTheatre
+{
+    public interface ISurgeryService
+    {
+        Task<IEnumerable<SurgeryDto>> GetAllSurgeriesAsync();
+        Task<SurgeryDto> GetSurgeryByIdAsync(Guid id);
+        Task<SurgeryDto> CreateSurgeryAsync(SurgeryDto surgeryDto);
+        Task UpdateSurgeryAsync(Guid id, SurgeryDto surgeryDto);
+        Task DeleteSurgeryAsync(Guid id);
+    }
+}

--- a/UniCareERP.Application/Services/OperationTheatre/OperationTheatreService.cs
+++ b/UniCareERP.Application/Services/OperationTheatre/OperationTheatreService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.OperationTheatre;
+
+namespace UniCareERP.Application.Services.OperationTheatre
+{
+    public class OperationTheatreService : IOperationTheatreService
+    {
+        public Task<OperationTheatreDto> CreateOperationTheatreAsync(OperationTheatreDto operationTheatreDto)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteOperationTheatreAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<OperationTheatreDto>> GetAllOperationTheatresAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<OperationTheatreDto> GetOperationTheatreByIdAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateOperationTheatreAsync(Guid id, OperationTheatreDto operationTheatreDto)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UniCareERP.Application/Services/OperationTheatre/SurgeryService.cs
+++ b/UniCareERP.Application/Services/OperationTheatre/SurgeryService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.OperationTheatre;
+
+namespace UniCareERP.Application.Services.OperationTheatre
+{
+    public class SurgeryService : ISurgeryService
+    {
+        public Task<SurgeryDto> CreateSurgeryAsync(SurgeryDto surgeryDto)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteSurgeryAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<SurgeryDto>> GetAllSurgeriesAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<SurgeryDto> GetSurgeryByIdAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateSurgeryAsync(Guid id, SurgeryDto surgeryDto)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UniCareERP.Application/Services/Vitals/IVitalService.cs
+++ b/UniCareERP.Application/Services/Vitals/IVitalService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.Vitals;
+
+namespace UniCareERP.Application.Services.Vitals
+{
+    public interface IVitalService
+    {
+        Task<IEnumerable<VitalDto>> GetVitalsForPatientAsync(Guid patientId);
+        Task<VitalDto> GetVitalByIdAsync(Guid id);
+        Task<VitalDto> CreateVitalAsync(VitalDto vitalDto);
+        Task UpdateVitalAsync(Guid id, VitalDto vitalDto);
+        Task DeleteVitalAsync(Guid id);
+    }
+}

--- a/UniCareERP.Application/Services/Vitals/VitalService.cs
+++ b/UniCareERP.Application/Services/Vitals/VitalService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.Vitals;
+
+namespace UniCareERP.Application.Services.Vitals
+{
+    public class VitalService : IVitalService
+    {
+        public Task<VitalDto> CreateVitalAsync(VitalDto vitalDto)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteVitalAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<VitalDto> GetVitalByIdAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<VitalDto>> GetVitalsForPatientAsync(Guid patientId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateVitalAsync(Guid id, VitalDto vitalDto)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UniCareERP.Domain/Entities/OperationTheatre/OperationTheatre.cs
+++ b/UniCareERP.Domain/Entities/OperationTheatre/OperationTheatre.cs
@@ -1,0 +1,10 @@
+namespace UniCareERP.Domain.Entities.OperationTheatre
+{
+    public class OperationTheatre
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Location { get; set; }
+        public bool IsAvailable { get; set; }
+    }
+}

--- a/UniCareERP.Domain/Entities/OperationTheatre/Surgery.cs
+++ b/UniCareERP.Domain/Entities/OperationTheatre/Surgery.cs
@@ -1,0 +1,22 @@
+using System;
+using UniCareERP.Domain.Entities.Patients;
+using UniCareERP.Domain.Entities.HR;
+
+namespace UniCareERP.Domain.Entities.OperationTheatre
+{
+    public class Surgery
+    {
+        public Guid Id { get; set; }
+        public string SurgeryName { get; set; }
+        public Guid PatientId { get; set; }
+        public Patient Patient { get; set; }
+        public Guid OperationTheatreId { get; set; }
+        public OperationTheatre OperationTheatre { get; set; }
+        public DateTime ScheduledDateTime { get; set; }
+        public Guid PrimarySurgeonId { get; set; }
+        public Employee PrimarySurgeon { get; set; }
+        public Guid AnesthetistId { get; set; }
+        public Employee Anesthetist { get; set; }
+        public string Notes { get; set; }
+    }
+}

--- a/UniCareERP.Domain/Entities/OperationTheatre/SurgeryChecklist.cs
+++ b/UniCareERP.Domain/Entities/OperationTheatre/SurgeryChecklist.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace UniCareERP.Domain.Entities.OperationTheatre
+{
+    public class SurgeryChecklist
+    {
+        public Guid Id { get; set; }
+        public Guid SurgeryId { get; set; }
+        public Surgery Surgery { get; set; }
+        public string ChecklistName { get; set; }
+        public bool IsCompleted { get; set; }
+    }
+}

--- a/UniCareERP.Domain/Entities/Vitals/Vital.cs
+++ b/UniCareERP.Domain/Entities/Vitals/Vital.cs
@@ -1,0 +1,25 @@
+using System;
+using UniCareERP.Domain.Entities.Patients;
+
+namespace UniCareERP.Domain.Entities.Vitals
+{
+    public class Vital
+    {
+        public Guid Id { get; set; }
+
+        public Guid PatientId { get; set; }
+        public Patient Patient { get; set; }
+
+        public string RecordedById { get; set; }
+        public ApplicationUser RecordedBy { get; set; }
+
+        public DateTime RecordedAt { get; set; }
+
+        public decimal Temperature { get; set; } // in Celsius
+        public int BloodPressureSystolic { get; set; }
+        public int BloodPressureDiastolic { get; set; }
+        public int HeartRate { get; set; } // Pulse
+        public int RespiratoryRate { get; set; }
+        public int OxygenSaturation { get; set; } // SpO2
+    }
+}

--- a/UniCareERP.Domain/Enums/OperationTheatre/ChecklistStatus.cs
+++ b/UniCareERP.Domain/Enums/OperationTheatre/ChecklistStatus.cs
@@ -1,0 +1,9 @@
+namespace UniCareERP.Domain.Enums.OperationTheatre
+{
+    public enum ChecklistStatus
+    {
+        Pending,
+        Completed,
+        NotApplicable
+    }
+}

--- a/UniCareERP.Domain/Enums/OperationTheatre/SurgeryStatus.cs
+++ b/UniCareERP.Domain/Enums/OperationTheatre/SurgeryStatus.cs
@@ -1,0 +1,10 @@
+namespace UniCareERP.Domain.Enums.OperationTheatre
+{
+    public enum SurgeryStatus
+    {
+        Scheduled,
+        InProgress,
+        Completed,
+        Cancelled
+    }
+}

--- a/UniCareERP.Infrastructure/Data/UniCareDbContext.cs
+++ b/UniCareERP.Infrastructure/Data/UniCareDbContext.cs
@@ -9,6 +9,7 @@ using UniCareERP.Domain.Entities.Patients;
 using UniCareERP.Domain.Entities.Procedures;
 using UniCareERP.Domain.Entities.Lab;
 using UniCareERP.Domain.Entities.Inpatient;
+using UniCareERP.Domain.Entities.OperationTheatre;
 
 namespace UniCareERP.Infrastructure.Data
 {
@@ -58,6 +59,11 @@ namespace UniCareERP.Infrastructure.Data
         public virtual DbSet<LabTest> LabTests { get; set; } = null!;
         public virtual DbSet<LabOrder> LabOrders { get; set; } = null!;
         public virtual DbSet<Permission> Permissions { get; set; } = null!;
+
+        // Operation Theatre Management
+        public virtual DbSet<OperationTheatre> OperationTheatres { get; set; } = null!;
+        public virtual DbSet<Surgery> Surgeries { get; set; } = null!;
+        public virtual DbSet<SurgeryChecklist> SurgeryChecklists { get; set; } = null!;
 
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/UniCareERP.Infrastructure/Data/UniCareDbContext.cs
+++ b/UniCareERP.Infrastructure/Data/UniCareDbContext.cs
@@ -10,6 +10,7 @@ using UniCareERP.Domain.Entities.Procedures;
 using UniCareERP.Domain.Entities.Lab;
 using UniCareERP.Domain.Entities.Inpatient;
 using UniCareERP.Domain.Entities.OperationTheatre;
+using UniCareERP.Domain.Entities.Vitals;
 
 namespace UniCareERP.Infrastructure.Data
 {
@@ -65,6 +66,9 @@ namespace UniCareERP.Infrastructure.Data
         public virtual DbSet<Surgery> Surgeries { get; set; } = null!;
         public virtual DbSet<SurgeryChecklist> SurgeryChecklists { get; set; } = null!;
 
+        // Vitals Management
+        public virtual DbSet<Vital> Vitals { get; set; } = null!;
+
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -101,6 +105,10 @@ namespace UniCareERP.Infrastructure.Data
             builder.Entity<SalaryStructure>().Property(p => p.ProvidentFund).HasPrecision(18, 2);
             builder.Entity<InventoryItem>().Property(p => p.CostPrice).HasPrecision(18, 2);
             builder.Entity<InventoryItem>().Property(p => p.UnitPrice).HasPrecision(18, 2);
+
+            builder.Entity<Vital>()
+                .Property(v => v.Temperature)
+                .HasPrecision(5, 2);
 
             builder.Entity<ProcedureCharge>(b =>
             {

--- a/UniCareERP.Infrastructure/Data/UniCareDbContextFactory.cs
+++ b/UniCareERP.Infrastructure/Data/UniCareDbContextFactory.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace UniCareERP.Infrastructure.Data
+{
+    public class UniCareDbContextFactory : IDesignTimeDbContextFactory<UniCareDbContext>
+    {
+        public UniCareDbContext CreateDbContext(string[] args)
+        {
+            // Get environment
+            string environment = System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+            // Build config
+            IConfiguration config = new ConfigurationBuilder()
+                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../UniCareERP.Web"))
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{environment}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            // Get connection string
+            var optionsBuilder = new DbContextOptionsBuilder<UniCareDbContext>();
+            var connectionString = config.GetConnectionString("DefaultConnection");
+            optionsBuilder.UseSqlServer(connectionString);
+            return new UniCareDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/UniCareERP.Infrastructure/Migrations/20250816102045_AddOperationTheatreModule.Designer.cs
+++ b/UniCareERP.Infrastructure/Migrations/20250816102045_AddOperationTheatreModule.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UniCareERP.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using UniCareERP.Infrastructure.Data;
 namespace UniCareERP.Infrastructure.Migrations
 {
     [DbContext(typeof(UniCareDbContext))]
-    partial class UniCareDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250816102045_AddOperationTheatreModule")]
+    partial class AddOperationTheatreModule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UniCareERP.Infrastructure/Migrations/20250816102045_AddOperationTheatreModule.cs
+++ b/UniCareERP.Infrastructure/Migrations/20250816102045_AddOperationTheatreModule.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UniCareERP.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOperationTheatreModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OperationTheatres",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Location = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    IsAvailable = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OperationTheatres", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Surgeries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SurgeryName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PatientId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OperationTheatreId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ScheduledDateTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    PrimarySurgeonId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AnesthetistId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Surgeries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Surgeries_Employees_AnesthetistId",
+                        column: x => x.AnesthetistId,
+                        principalTable: "Employees",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Surgeries_Employees_PrimarySurgeonId",
+                        column: x => x.PrimarySurgeonId,
+                        principalTable: "Employees",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Surgeries_OperationTheatres_OperationTheatreId",
+                        column: x => x.OperationTheatreId,
+                        principalTable: "OperationTheatres",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Surgeries_Patients_PatientId",
+                        column: x => x.PatientId,
+                        principalTable: "Patients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SurgeryChecklists",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SurgeryId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ChecklistName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    IsCompleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SurgeryChecklists", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SurgeryChecklists_Surgeries_SurgeryId",
+                        column: x => x.SurgeryId,
+                        principalTable: "Surgeries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Surgeries_AnesthetistId",
+                table: "Surgeries",
+                column: "AnesthetistId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Surgeries_OperationTheatreId",
+                table: "Surgeries",
+                column: "OperationTheatreId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Surgeries_PatientId",
+                table: "Surgeries",
+                column: "PatientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Surgeries_PrimarySurgeonId",
+                table: "Surgeries",
+                column: "PrimarySurgeonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SurgeryChecklists_SurgeryId",
+                table: "SurgeryChecklists",
+                column: "SurgeryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SurgeryChecklists");
+
+            migrationBuilder.DropTable(
+                name: "Surgeries");
+
+            migrationBuilder.DropTable(
+                name: "OperationTheatres");
+        }
+    }
+}

--- a/UniCareERP.Infrastructure/Migrations/20250816103606_AddVitalsModule.Designer.cs
+++ b/UniCareERP.Infrastructure/Migrations/20250816103606_AddVitalsModule.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UniCareERP.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using UniCareERP.Infrastructure.Data;
 namespace UniCareERP.Infrastructure.Migrations
 {
     [DbContext(typeof(UniCareDbContext))]
-    partial class UniCareDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250816103606_AddVitalsModule")]
+    partial class AddVitalsModule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UniCareERP.Infrastructure/Migrations/20250816103606_AddVitalsModule.cs
+++ b/UniCareERP.Infrastructure/Migrations/20250816103606_AddVitalsModule.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UniCareERP.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVitalsModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Vitals",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PatientId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RecordedById = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    RecordedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Temperature = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: false),
+                    BloodPressureSystolic = table.Column<int>(type: "int", nullable: false),
+                    BloodPressureDiastolic = table.Column<int>(type: "int", nullable: false),
+                    HeartRate = table.Column<int>(type: "int", nullable: false),
+                    RespiratoryRate = table.Column<int>(type: "int", nullable: false),
+                    OxygenSaturation = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Vitals", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Vitals_AspNetUsers_RecordedById",
+                        column: x => x.RecordedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Vitals_Patients_PatientId",
+                        column: x => x.PatientId,
+                        principalTable: "Patients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Vitals_PatientId",
+                table: "Vitals",
+                column: "PatientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Vitals_RecordedById",
+                table: "Vitals",
+                column: "RecordedById");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Vitals");
+        }
+    }
+}

--- a/UniCareERP.Web/Controllers/OperationTheatreController.cs
+++ b/UniCareERP.Web/Controllers/OperationTheatreController.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.OperationTheatre;
+using UniCareERP.Application.Services.OperationTheatre;
+
+namespace UniCareERP.Web.Controllers
+{
+    public class OperationTheatreController : Controller
+    {
+        private readonly IOperationTheatreService _operationTheatreService;
+
+        public OperationTheatreController(IOperationTheatreService operationTheatreService)
+        {
+            _operationTheatreService = operationTheatreService;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var operationTheatres = await _operationTheatreService.GetAllOperationTheatresAsync();
+            return View(operationTheatres);
+        }
+
+        public async Task<IActionResult> Details(Guid id)
+        {
+            var operationTheatre = await _operationTheatreService.GetOperationTheatreByIdAsync(id);
+            if (operationTheatre == null)
+            {
+                return NotFound();
+            }
+            return View(operationTheatre);
+        }
+
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(OperationTheatreDto operationTheatreDto)
+        {
+            if (ModelState.IsValid)
+            {
+                await _operationTheatreService.CreateOperationTheatreAsync(operationTheatreDto);
+                return RedirectToAction(nameof(Index));
+            }
+            return View(operationTheatreDto);
+        }
+
+        public async Task<IActionResult> Edit(Guid id)
+        {
+            var operationTheatre = await _operationTheatreService.GetOperationTheatreByIdAsync(id);
+            if (operationTheatre == null)
+            {
+                return NotFound();
+            }
+            return View(operationTheatre);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(Guid id, OperationTheatreDto operationTheatreDto)
+        {
+            if (id != operationTheatreDto.Id)
+            {
+                return BadRequest();
+            }
+
+            if (ModelState.IsValid)
+            {
+                await _operationTheatreService.UpdateOperationTheatreAsync(id, operationTheatreDto);
+                return RedirectToAction(nameof(Index));
+            }
+            return View(operationTheatreDto);
+        }
+
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var operationTheatre = await _operationTheatreService.GetOperationTheatreByIdAsync(id);
+            if (operationTheatre == null)
+            {
+                return NotFound();
+            }
+            return View(operationTheatre);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(Guid id)
+        {
+            await _operationTheatreService.DeleteOperationTheatreAsync(id);
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/UniCareERP.Web/Controllers/VitalsController.cs
+++ b/UniCareERP.Web/Controllers/VitalsController.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+using UniCareERP.Application.DTOs.Vitals;
+using UniCareERP.Application.Services.Vitals;
+
+namespace UniCareERP.Web.Controllers
+{
+    public class VitalsController : Controller
+    {
+        private readonly IVitalService _vitalService;
+
+        public VitalsController(IVitalService vitalService)
+        {
+            _vitalService = vitalService;
+        }
+
+        public async Task<IActionResult> Index(Guid patientId)
+        {
+            var vitals = await _vitalService.GetVitalsForPatientAsync(patientId);
+            return View(vitals);
+        }
+
+        public IActionResult Create(Guid patientId)
+        {
+            var vitalDto = new VitalDto { PatientId = patientId };
+            return View(vitalDto);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(VitalDto vitalDto)
+        {
+            if (ModelState.IsValid)
+            {
+                // Assuming the logged-in user's ID is available
+                // vitalDto.RecordedById = ...;
+                await _vitalService.CreateVitalAsync(vitalDto);
+                return RedirectToAction(nameof(Index), new { patientId = vitalDto.PatientId });
+            }
+            return View(vitalDto);
+        }
+    }
+}

--- a/UniCareERP.Web/Views/OperationTheatre/Create.cshtml
+++ b/UniCareERP.Web/Views/OperationTheatre/Create.cshtml
@@ -1,0 +1,43 @@
+@model UniCareERP.Application.DTOs.OperationTheatre.OperationTheatreDto
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>OperationTheatre</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Location" class="control-label"></label>
+                <input asp-for="Location" class="form-control" />
+                <span asp-validation-for="Location" class="text-danger"></span>
+            </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="IsAvailable" /> @Html.DisplayNameFor(model => model.IsAvailable)
+                </label>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/UniCareERP.Web/Views/OperationTheatre/Index.cshtml
+++ b/UniCareERP.Web/Views/OperationTheatre/Index.cshtml
@@ -1,0 +1,47 @@
+@model IEnumerable<UniCareERP.Application.DTOs.OperationTheatre.OperationTheatreDto>
+
+@{
+    ViewData["Title"] = "Operation Theatres";
+}
+
+<h1>Operation Theatres</h1>
+
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Location)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.IsAvailable)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Location)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.IsAvailable)
+            </td>
+            <td>
+                <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
+                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+                <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/UniCareERP.Web/Views/Vitals/Create.cshtml
+++ b/UniCareERP.Web/Views/Vitals/Create.cshtml
@@ -1,0 +1,60 @@
+@model UniCareERP.Application.DTOs.Vitals.VitalDto
+
+@{
+    ViewData["Title"] = "Record Vitals";
+}
+
+<h1>Record Vitals</h1>
+
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="PatientId" />
+
+            <div class="form-group">
+                <label asp-for="TemperatureC" class="control-label">Temperature (°C)</label>
+                <input asp-for="TemperatureC" class="form-control" />
+                <span asp-validation-for="TemperatureC" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="BloodPressureSystolic" class="control-label">Blood Pressure (Systolic)</label>
+                <input asp-for="BloodPressureSystolic" class="form-control" />
+                <span asp-validation-for="BloodPressureSystolic" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="BloodPressureDiastolic" class="control-label">Blood Pressure (Diastolic)</label>
+                <input asp-for="BloodPressureDiastolic" class="form-control" />
+                <span asp-validation-for="BloodPressureDiastolic" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="HeartRate" class="control-label">Heart Rate</label>
+                <input asp-for="HeartRate" class="form-control" />
+                <span asp-validation-for="HeartRate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="RespiratoryRate" class="control-label">Respiratory Rate</label>
+                <input asp-for="RespiratoryRate" class="form-control" />
+                <span asp-validation-for="RespiratoryRate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="OxygenSaturation" class="control-label">Oxygen Saturation (%)</label>
+                <input asp-for="OxygenSaturation" class="form-control" />
+                <span asp-validation-for="OxygenSaturation" class="text-danger"></span>
+            </div>
+
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index" asp-route-patientId="@Model.PatientId">Back to Vitals</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/UniCareERP.Web/Views/Vitals/Index.cshtml
+++ b/UniCareERP.Web/Views/Vitals/Index.cshtml
@@ -1,0 +1,111 @@
+@model IEnumerable<UniCareERP.Application.DTOs.Vitals.VitalDto>
+
+@{
+    ViewData["Title"] = "Patient Vitals";
+    var patientId = Model.FirstOrDefault()?.PatientId;
+}
+
+<h1>Vitals for Patient</h1>
+
+@if (patientId != null)
+{
+    <p>
+        <a asp-action="Create" asp-route-patientId="@patientId">Record New Vitals</a>
+    </p>
+}
+
+
+<div class="row">
+    <div class="col-md-12">
+        <h4>Vitals History</h4>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Date & Time</th>
+                    <th>Temp (°C)</th>
+                    <th>BP (Sys/Dia)</th>
+                    <th>Heart Rate</th>
+                    <th>Resp. Rate</th>
+                    <th>SpO2 (%)</th>
+                    <th>Recorded By</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td>@item.RecordedAt.ToString("g")</td>
+                        <td>@item.TemperatureC</td>
+                        <td>@item.BloodPressureSystolic / @item.BloodPressureDiastolic</td>
+                        <td>@item.HeartRate</td>
+                        <td>@item.RespiratoryRate</td>
+                        <td>@item.OxygenSaturation</td>
+                        <td>@item.RecordedByName</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        <h4>Vitals Chart</h4>
+        <canvas id="vitalsChart"></canvas>
+    </div>
+</div>
+
+
+@section Scripts {
+    <script src="~/lib/chartjs/Chart.min.js"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            var ctx = document.getElementById('vitalsChart').getContext('2d');
+            var chart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: @Html.Raw(Json.Serialize(Model.Select(v => v.RecordedAt.ToString("g")).Reverse())),
+                    datasets: [
+                        {
+                            label: 'Temperature (°C)',
+                            data: @Html.Raw(Json.Serialize(Model.Select(v => v.TemperatureC).Reverse())),
+                            borderColor: 'red',
+                            fill: false
+                        },
+                        {
+                            label: 'Heart Rate',
+                            data: @Html.Raw(Json.Serialize(Model.Select(v => v.HeartRate).Reverse())),
+                            borderColor: 'blue',
+                            fill: false
+                        },
+                        {
+                            label: 'Oxygen Saturation (%)',
+                            data: @Html.Raw(Json.Serialize(Model.Select(v => v.OxygenSaturation).Reverse())),
+                            borderColor: 'green',
+                            fill: false
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        x: {
+                            display: true,
+                            title: {
+                                display: true,
+                                text: 'Date & Time'
+                            }
+                        },
+                        y: {
+                            display: true,
+                            title: {
+                                display: true,
+                                text: 'Value'
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    </script>
+}


### PR DESCRIPTION
This commit introduces the initial structure for the Operation Theatre (OT) module.

Key changes include:
- **Domain Layer**: Added `OperationTheatre`, `Surgery`, and `SurgeryChecklist` entities, along with `SurgeryStatus` and `ChecklistStatus` enums.
- **Application Layer**: Created DTOs (`OperationTheatreDto`, `SurgeryDto`, `SurgeryChecklistDto`) and service interfaces (`IOperationTheatreService`, `ISurgeryService`) with placeholder implementations.
- **Infrastructure Layer**: Updated `UniCareDbContext` with the new entities and created a database migration (`AddOperationTheatreModule`) to reflect the schema changes.
- **Web Layer**: Created the `OperationTheatreController` and the corresponding `Index` and `Create` views to start building the user interface.